### PR TITLE
Support private config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Private config
+config.private.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/main.py
+++ b/main.py
@@ -1,34 +1,19 @@
 # Singleton config
-import asyncio
-import json
-
-from fastapi.staticfiles import StaticFiles
 from model.state import state
 
 # HTTP server
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from routes.state_routes import router as state_router
 from routes.instruction_routes import router as instruction_router
 
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    render_task = asyncio.create_task(state.render_loop())
-    state.pixels.brightness = 1.0
-        
-    yield 
     # actions on exit
-    state.pixels.brightness = 0.0
-    state.pixels.show()
-    
-    with open('config.json', 'w') as f:
-        json.dump(state.config.to_dict(), f, indent=4)
-
-    state.stop_event.set()
-    await render_task
-
+    yield
+    await state.deconstruct()
 
 app = FastAPI(
     title="Backlight HTTP endpoint",


### PR DESCRIPTION
Backlight now attempts to gather configurations from the file in the following order:
1. `config.private.json` (git-ignored)
2. `config.json`
